### PR TITLE
feat: 初期Reactアプリケーションを構築

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2022: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  plugins: ['@typescript-eslint', 'react-hooks', 'react-refresh'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  rules: {
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Typing Arena</title>
+    <meta
+      name="description"
+      content="e-typingスタイルの競技・練習ができるタイピングサービス"
+    />
+  </head>
+  <body>
+    <noscript>このアプリを利用するにはJavaScriptを有効にしてください。</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "typing-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.32.1",
+    "clsx": "^2.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/src/app/App.module.css
+++ b/src/app/App.module.css
@@ -1,0 +1,13 @@
+.appShell {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.main {
+  flex: 1;
+  padding: 1.5rem 1rem 2.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react';
+import { AppRoutes } from './routes/AppRoutes.tsx';
+import styles from './App.module.css';
+import { NavigationBar } from '@/components/navigation/NavigationBar.tsx';
+
+const App = () => {
+  return (
+    <div className={styles.appShell}>
+      <a className="visually-hidden" href="#main-content">
+        メインコンテンツへスキップ
+      </a>
+      <NavigationBar />
+      <main id="main-content" className={styles.main}>
+        <Suspense fallback={<p>読み込み中...</p>}>
+          <AppRoutes />
+        </Suspense>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/src/app/routes/AdminConsole.tsx
+++ b/src/app/routes/AdminConsole.tsx
@@ -1,0 +1,13 @@
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { AdminForms } from '@/components/typing/AdminForms.tsx';
+
+export const AdminConsole = () => {
+  return (
+    <PageContainer
+      title="管理コンソール"
+      description="コンテストの作成・プロンプト管理・ライブ監視を行います"
+    >
+      <AdminForms />
+    </PageContainer>
+  );
+};

--- a/src/app/routes/AppRoutes.tsx
+++ b/src/app/routes/AppRoutes.tsx
@@ -1,0 +1,32 @@
+import { useRoutes } from 'react-router-dom';
+import { Landing } from './Landing.tsx';
+import { SignIn } from './SignIn.tsx';
+import { SignUp } from './SignUp.tsx';
+import { PasswordReset } from './PasswordReset.tsx';
+import { Dashboard } from './Dashboard.tsx';
+import { Practice } from './Practice.tsx';
+import { ContestLobby } from './ContestLobby.tsx';
+import { TypingPlay } from './TypingPlay.tsx';
+import { Result } from './Result.tsx';
+import { Leaderboard } from './Leaderboard.tsx';
+import { AdminConsole } from './AdminConsole.tsx';
+import { NotFound } from './NotFound.tsx';
+
+export const AppRoutes = () => {
+  const element = useRoutes([
+    { path: '/', element: <Landing /> },
+    { path: '/signin', element: <SignIn /> },
+    { path: '/signup', element: <SignUp /> },
+    { path: '/password-reset', element: <PasswordReset /> },
+    { path: '/dashboard', element: <Dashboard /> },
+    { path: '/practice', element: <Practice /> },
+    { path: '/contests/:contestId', element: <ContestLobby /> },
+    { path: '/typing/:contestId', element: <TypingPlay /> },
+    { path: '/result/:sessionId', element: <Result /> },
+    { path: '/leaderboard/:contestId', element: <Leaderboard /> },
+    { path: '/admin', element: <AdminConsole /> },
+    { path: '*', element: <NotFound /> },
+  ]);
+
+  return element;
+};

--- a/src/app/routes/Auth.module.css
+++ b/src/app/routes/Auth.module.css
@@ -1,0 +1,52 @@
+.form {
+  display: grid;
+  gap: 1rem;
+  max-width: 480px;
+}
+
+.field {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.field label {
+  font-weight: 600;
+}
+
+.field input,
+.form textarea,
+.form select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #c7d2e2;
+  background-color: #fdfefe;
+}
+
+.checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.checkbox input {
+  margin-top: 0.2rem;
+}
+
+.submit {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(120deg, #22438a, #1b8cd8);
+  color: #ffffff;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.switchLink a {
+  margin-left: 0.25rem;
+}

--- a/src/app/routes/ContestLobby.module.css
+++ b/src/app/routes/ContestLobby.module.css
@@ -1,0 +1,62 @@
+.primaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+  text-decoration: none;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.detailList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.detailList div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.detailList dt {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.detailList dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.joinForm {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: #f8fafc;
+}
+
+.joinForm input {
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid #cbd5e1;
+}
+
+.joinForm button {
+  justify-self: flex-start;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.6rem;
+  border: none;
+  background-color: #22438a;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/app/routes/ContestLobby.tsx
+++ b/src/app/routes/ContestLobby.tsx
@@ -1,0 +1,78 @@
+import { FormEvent, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { useContestQuery } from '@/features/contest/api/contestQueries.ts';
+import styles from './ContestLobby.module.css';
+
+export const ContestLobby = () => {
+  const { contestId = '' } = useParams();
+  const { data: contest, isLoading } = useContestQuery(contestId, Boolean(contestId));
+  const [code, setCode] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (contest?.visibility === 'private' && code.trim() === '') {
+      setMessage('参加コードを入力してください');
+      return;
+    }
+    setMessage('デモ環境のため、参加リクエストは送信されません。');
+  };
+
+  return (
+    <PageContainer
+      title={contest?.title ?? 'コンテスト情報'}
+      description={contest?.description ?? 'コンテストの概要と参加条件を確認します'}
+      actions={
+        contest ? (
+          <Link className={styles.primaryAction} to={`/typing/${contest.id}`}>
+            セッションを開始
+          </Link>
+        ) : undefined
+      }
+    >
+      {isLoading ? <p>読み込み中...</p> : null}
+      {!contest && !isLoading ? <p>コンテストが見つかりません。</p> : null}
+      {contest ? (
+        <div className={styles.grid}>
+          <section>
+            <h2>ルール概要</h2>
+            <dl className={styles.detailList}>
+              <div>
+                <dt>制限時間</dt>
+                <dd>{contest.timeLimitSec} 秒</dd>
+              </div>
+              <div>
+                <dt>最大試行回数</dt>
+                <dd>{contest.maxAttempts === 0 ? '無制限' : `${contest.maxAttempts} 回`}</dd>
+              </div>
+              <div>
+                <dt>Backspace</dt>
+                <dd>{contest.allowBackspace ? '使用可' : '使用不可'}</dd>
+              </div>
+              <div>
+                <dt>公開設定</dt>
+                <dd>{contest.leaderboardVisibility}</dd>
+              </div>
+            </dl>
+          </section>
+          <section>
+            <h2>参加コード</h2>
+            <form className={styles.joinForm} onSubmit={handleSubmit}>
+              <label htmlFor="join-code">参加コードを入力</label>
+              <input
+                id="join-code"
+                value={code}
+                onChange={(event) => setCode(event.target.value)}
+                placeholder={contest.visibility === 'private' ? 'コード必須' : '公開コンテスト'}
+                aria-required={contest.visibility === 'private'}
+              />
+              <button type="submit">参加登録</button>
+              {message ? <p role="status">{message}</p> : null}
+            </form>
+          </section>
+        </div>
+      ) : null}
+    </PageContainer>
+  );
+};

--- a/src/app/routes/Dashboard.module.css
+++ b/src/app/routes/Dashboard.module.css
@@ -1,0 +1,57 @@
+.contestList {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  border-radius: 0.75rem;
+  border: 1px solid #d0d7e2;
+  padding: 1rem;
+  background-color: #ffffff;
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.meta {
+  display: flex;
+  gap: 1.5rem;
+  margin: 1rem 0;
+}
+
+.meta div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.meta dt {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.meta dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid #1b8cd8;
+  color: #1b8cd8;
+  text-decoration: none;
+}
+
+.actions a:last-of-type {
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+}

--- a/src/app/routes/Dashboard.tsx
+++ b/src/app/routes/Dashboard.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { useContestsQuery } from '@/features/contest/api/contestQueries.ts';
+import styles from './Dashboard.module.css';
+
+export const Dashboard = () => {
+  const { data, isLoading } = useContestsQuery();
+
+  return (
+    <PageContainer
+      title="ダッシュボード"
+      description="参加可能なコンテストと最近の成績を確認できます"
+    >
+      <section aria-label="コンテスト一覧" className={styles.contestList}>
+        {isLoading ? <p>読み込み中...</p> : null}
+        {data?.map((contest) => (
+          <article key={contest.id} className={styles.card}>
+            <h2>{contest.title}</h2>
+            <p>{contest.description}</p>
+            <dl className={styles.meta}>
+              <div>
+                <dt>時間制限</dt>
+                <dd>{contest.timeLimitSec} 秒</dd>
+              </div>
+              <div>
+                <dt>最大試行</dt>
+                <dd>{contest.maxAttempts === 0 ? '無制限' : `${contest.maxAttempts} 回`}</dd>
+              </div>
+              <div>
+                <dt>公開範囲</dt>
+                <dd>{contest.visibility === 'public' ? '公開' : '非公開'}</dd>
+              </div>
+            </dl>
+            <div className={styles.actions}>
+              <Link to={`/contests/${contest.id}`}>詳細</Link>
+              <Link to={`/typing/${contest.id}`}>今すぐ挑戦</Link>
+            </div>
+          </article>
+        ))}
+      </section>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/Landing.module.css
+++ b/src/app/routes/Landing.module.css
@@ -1,0 +1,60 @@
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.primaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryCta:hover,
+.primaryCta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(27, 140, 216, 0.25);
+}
+
+.secondaryCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid #1b8cd8;
+  color: #1b8cd8;
+  background-color: #ffffff;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.featureGrid article {
+  border: 1px solid #e3e8ee;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #f9fbfd;
+}
+
+.featureGrid h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.featureGrid p {
+  margin-bottom: 0;
+  color: #4d5c6a;
+}

--- a/src/app/routes/Landing.tsx
+++ b/src/app/routes/Landing.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import styles from './Landing.module.css';
+
+export const Landing = () => {
+  return (
+    <PageContainer
+      title="Typing Arena"
+      description="e-typingの緊張感と分析機能を備えたモダンなタイピング学習・競技プラットフォーム"
+      actions={
+        <div className={styles.actions}>
+          <Link className={styles.primaryCta} to="/signup">
+            今すぐ無料で始める
+          </Link>
+          <Link className={styles.secondaryCta} to="/signin">
+            ログイン
+          </Link>
+        </div>
+      }
+    >
+      <section className={styles.featureGrid} aria-label="主な特徴">
+        <article>
+          <h2>ローマ字練習に最適化</h2>
+          <p>
+            日本語表示と正規化済みローマ字列を同時に提示し、IMEを使わずに正確なホームポジションを身に付けられます。
+          </p>
+        </article>
+        <article>
+          <h2>大会機能とライブランキング</h2>
+          <p>
+            コンテストに参加するとリアルタイムに順位が更新され、練習の成果を仲間と競い合えます。
+          </p>
+        </article>
+        <article>
+          <h2>緻密なリプレイと分析</h2>
+          <p>
+            キーログ、CPM/WPM、正確率推移などを詳細に可視化し、自分の癖を発見して改善できます。
+          </p>
+        </article>
+      </section>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/Leaderboard.module.css
+++ b/src/app/routes/Leaderboard.module.css
@@ -1,0 +1,32 @@
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+caption {
+  padding: 0.75rem;
+  font-weight: 600;
+}
+
+thead {
+  background-color: #0f172a;
+  color: #f8fafc;
+}
+
+td,
+th {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+tbody tr:nth-of-type(even) {
+  background-color: #f8fafc;
+}
+
+tbody tr:hover {
+  background-color: #e0f2fe;
+}

--- a/src/app/routes/Leaderboard.tsx
+++ b/src/app/routes/Leaderboard.tsx
@@ -1,0 +1,44 @@
+import { useParams } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { useLeaderboardQuery } from '@/features/contest/api/contestQueries.ts';
+import styles from './Leaderboard.module.css';
+
+export const Leaderboard = () => {
+  const { contestId = '' } = useParams();
+  const { data, isLoading, error } = useLeaderboardQuery(contestId, Boolean(contestId));
+
+  return (
+    <PageContainer
+      title="Leaderboard"
+      description={contestId ? `コンテストID: ${contestId}` : 'コンテストを選択してください'}
+    >
+      {isLoading ? <p>読み込み中...</p> : null}
+      {error ? <p role="alert">ランキングを取得できませんでした。</p> : null}
+      {data ? (
+        <table className={styles.table}>
+          <caption>上位10名のスコア</caption>
+          <thead>
+            <tr>
+              <th scope="col">順位</th>
+              <th scope="col">ユーザー</th>
+              <th scope="col">スコア</th>
+              <th scope="col">CPM</th>
+              <th scope="col">正確率</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.top.map((entry) => (
+              <tr key={entry.rank}>
+                <td>{entry.rank}</td>
+                <td>{entry.user}</td>
+                <td>{entry.score}</td>
+                <td>{entry.cpm}</td>
+                <td>{(entry.accuracy * 100).toFixed(1)}%</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : null}
+    </PageContainer>
+  );
+};

--- a/src/app/routes/NotFound.tsx
+++ b/src/app/routes/NotFound.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+
+export const NotFound = () => {
+  return (
+    <PageContainer title="ページが見つかりません" description="指定のページは存在しませんでした">
+      <p>
+        URLを再確認するか、<Link to="/">トップページ</Link>に戻ってください。
+      </p>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/PasswordReset.tsx
+++ b/src/app/routes/PasswordReset.tsx
@@ -1,0 +1,35 @@
+import { FormEvent, useState } from 'react';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import styles from './Auth.module.css';
+
+export const PasswordReset = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    setMessage('デモ環境のため、再設定メールは送信されません。');
+  };
+
+  return (
+    <PageContainer title="パスワード再設定" description="登録済みメールアドレスに再設定用リンクを送信します">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" className={styles.submit}>
+          再設定リンクを送信
+        </button>
+        {message ? <p role="status">{message}</p> : null}
+      </form>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/Practice.module.css
+++ b/src/app/routes/Practice.module.css
@@ -1,0 +1,49 @@
+.section {
+  display: grid;
+  gap: 1rem;
+}
+
+.promptList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.promptList button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.6rem;
+  border: 1px solid #1b8cd8;
+  background-color: #fff;
+  color: #1b8cd8;
+  cursor: pointer;
+}
+
+.active {
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff !important;
+}
+
+.checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.preview {
+  border: 1px dashed #94a3b8;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: #f8fafc;
+}
+
+.preview code {
+  display: inline-block;
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}

--- a/src/app/routes/Practice.tsx
+++ b/src/app/routes/Practice.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import styles from './Practice.module.css';
+
+const practicePrompts = [
+  { id: 'romaji-1', label: '季節の挨拶', target: 'kyouhawa' },
+  { id: 'romaji-2', label: '駅名トレーニング', target: 'shinjukueki' },
+  { id: 'en-1', label: 'English pangram', target: 'thequickbrownfoxjumpsoverthelazydog' },
+];
+
+export const Practice = () => {
+  const [selectedPrompt, setSelectedPrompt] = useState(practicePrompts[0]);
+  const [showHint, setShowHint] = useState(true);
+
+  return (
+    <PageContainer
+      title="自由練習"
+      description="好きなお題を選んでローマ字ヒントのON/OFFを切り替えながら練習できます"
+    >
+      <section className={styles.section}>
+        <h2>お題選択</h2>
+        <ul className={styles.promptList}>
+          {practicePrompts.map((prompt) => (
+            <li key={prompt.id}>
+              <button
+                type="button"
+                className={prompt.id === selectedPrompt.id ? styles.active : ''}
+                onClick={() => setSelectedPrompt(prompt)}
+              >
+                {prompt.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.section}>
+        <h2>練習設定</h2>
+        <label className={styles.checkbox}>
+          <input
+            type="checkbox"
+            checked={showHint}
+            onChange={(event) => setShowHint(event.target.checked)}
+          />
+          ローマ字ヒントを表示する
+        </label>
+        <div className={styles.preview}>
+          <p>選択中のお題：{selectedPrompt.label}</p>
+          {showHint ? <code>{selectedPrompt.target}</code> : <p>ヒント非表示</p>}
+        </div>
+      </section>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/Result.module.css
+++ b/src/app/routes/Result.module.css
@@ -1,0 +1,41 @@
+.primaryButton {
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.7rem;
+  border: none;
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.summary {
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: #ffffff;
+}
+
+.summary h2 {
+  margin-top: 0;
+}
+
+.summary dl {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.summary dt {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.summary dd {
+  margin: 0;
+  font-weight: 600;
+}

--- a/src/app/routes/Result.tsx
+++ b/src/app/routes/Result.tsx
@@ -1,0 +1,77 @@
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { KeyStats } from '@/components/typing/KeyStats.tsx';
+import { formatAccuracy } from '@/lib/keyboard/typingUtils.ts';
+import { SessionResult } from '@/types/api.ts';
+import styles from './Result.module.css';
+
+type ResultLocationState = {
+  result?: SessionResult;
+  contest?: { title: string } | null;
+};
+
+export const Result = () => {
+  const { sessionId = '' } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as ResultLocationState | null;
+  const result = state?.result;
+
+  if (!result) {
+    return (
+      <PageContainer title="リザルト" description="結果情報が見つかりませんでした">
+        <p>直接アクセスされた場合はダッシュボードに戻ってください。</p>
+        <button type="button" onClick={() => navigate('/dashboard')} className={styles.primaryButton}>
+          ダッシュボードへ戻る
+        </button>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer
+      title="リザルト"
+      description={`${state?.contest?.title ?? 'コンテスト'} - セッションID: ${sessionId}`}
+      actions={
+        <button type="button" className={styles.primaryButton} onClick={() => navigate(-1)}>
+          前の画面へ戻る
+        </button>
+      }
+    >
+      <div className={styles.grid}>
+        <KeyStats
+          cpm={Math.round(result.cpm)}
+          wpm={Math.round(result.wpm)}
+          accuracy={result.accuracy}
+          errors={result.errors}
+          remainingSeconds={0}
+        />
+        <section className={styles.summary}>
+          <h2>概要</h2>
+          <dl>
+            <div>
+              <dt>スコア</dt>
+              <dd>{result.score}</dd>
+            </div>
+            <div>
+              <dt>正確率</dt>
+              <dd>{formatAccuracy(result.accuracy)}</dd>
+            </div>
+            <div>
+              <dt>ミス</dt>
+              <dd>{result.errors}</dd>
+            </div>
+            <div>
+              <dt>ログ総数</dt>
+              <dd>{result.keylog.length}</dd>
+            </div>
+            <div>
+              <dt>異常スコア</dt>
+              <dd>{result.clientFlags?.anomalyScore ?? 0}</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/SignIn.tsx
+++ b/src/app/routes/SignIn.tsx
@@ -1,0 +1,69 @@
+import { FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import styles from './Auth.module.css';
+
+export const SignIn = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [agreed, setAgreed] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!agreed) {
+      setMessage('利用規約への同意が必要です');
+      return;
+    }
+    setMessage('デモ環境のため、サーバー接続は行われません。');
+  };
+
+  return (
+    <PageContainer title="ログイン" description="登録済みのアカウントでサインインします">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.checkbox}>
+          <input
+            id="agree"
+            type="checkbox"
+            checked={agreed}
+            onChange={(event) => setAgreed(event.target.checked)}
+            required
+          />
+          <label htmlFor="agree">利用規約とプライバシーポリシーに同意します</label>
+        </div>
+        <button type="submit" className={styles.submit}>
+          サインイン
+        </button>
+        {message ? <p role="status">{message}</p> : null}
+        <p className={styles.switchLink}>
+          アカウントをお持ちでない場合は<Link to="/signup">新規登録</Link>へ
+        </p>
+        <p>
+          パスワードをお忘れの方は<Link to="/password-reset">再設定</Link>
+        </p>
+      </form>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/SignUp.tsx
+++ b/src/app/routes/SignUp.tsx
@@ -1,0 +1,78 @@
+import { FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import styles from './Auth.module.css';
+
+export const SignUp = () => {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [agreed, setAgreed] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!agreed) {
+      setMessage('利用規約への同意が必要です');
+      return;
+    }
+    setMessage('デモ環境のため、アカウント作成リクエストは送信されません。');
+  };
+
+  return (
+    <PageContainer title="新規登録" description="メールアドレスとパスワードでアカウントを作成します">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label htmlFor="username">ユーザー名</label>
+          <input
+            id="username"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            minLength={3}
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="email">メールアドレス</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="password">パスワード</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            minLength={8}
+            required
+          />
+        </div>
+        <div className={styles.checkbox}>
+          <input
+            id="agree"
+            type="checkbox"
+            checked={agreed}
+            onChange={(event) => setAgreed(event.target.checked)}
+            required
+          />
+          <label htmlFor="agree">利用規約とプライバシーポリシーに同意します</label>
+        </div>
+        <button type="submit" className={styles.submit}>
+          アカウントを作成
+        </button>
+        {message ? <p role="status">{message}</p> : null}
+        <p className={styles.switchLink}>
+          すでにアカウントをお持ちの場合は<Link to="/signin">ログイン</Link>
+        </p>
+      </form>
+    </PageContainer>
+  );
+};

--- a/src/app/routes/TypingPlay.module.css
+++ b/src/app/routes/TypingPlay.module.css
@@ -1,0 +1,84 @@
+.primaryButton {
+  padding: 0.65rem 1.4rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 2fr 1fr;
+}
+
+@media (max-width: 992px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mainColumn {
+  display: grid;
+  gap: 1rem;
+}
+
+.inputSurface {
+  outline: none;
+  border: 2px dashed transparent;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  transition: border-color 0.2s ease;
+}
+
+.inputSurface:focus {
+  border-color: #1b8cd8;
+}
+
+.panelRow {
+  display: grid;
+  gap: 1rem;
+}
+
+.sidebar {
+  display: grid;
+  gap: 1rem;
+}
+
+.metaBox {
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: #ffffff;
+}
+
+.metaBox h2 {
+  margin-top: 0;
+}
+
+.metaBox dl {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.metaBox dt {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.metaBox dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.warning {
+  margin: 0;
+  padding: 0.75rem;
+  border-radius: 0.6rem;
+  background-color: #fee2e2;
+  color: #991b1b;
+  font-weight: 600;
+}

--- a/src/app/routes/TypingPlay.tsx
+++ b/src/app/routes/TypingPlay.tsx
@@ -1,0 +1,316 @@
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { KeyStats } from '@/components/typing/KeyStats.tsx';
+import { LeaderboardWidget } from '@/components/typing/LeaderboardWidget.tsx';
+import { Timer } from '@/components/typing/Timer.tsx';
+import { TypingCanvas } from '@/components/typing/TypingCanvas.tsx';
+import {
+  useContestQuery,
+  useFinishSessionMutation,
+  useStartSessionMutation,
+} from '@/features/contest/api/contestQueries.ts';
+import {
+  calculateAccuracy,
+  calculateAnomalyScore,
+  calculateCpm,
+  calculateScore,
+  calculateWpm,
+} from '@/lib/keyboard/typingUtils.ts';
+import { KeyLogEntry, SessionResult, StartSessionRes } from '@/types/api.ts';
+import styles from './TypingPlay.module.css';
+
+export const TypingPlay = () => {
+  const { contestId = '' } = useParams();
+  const { data: contest } = useContestQuery(contestId, Boolean(contestId));
+  const startSession = useStartSessionMutation();
+  const finishSession = useFinishSessionMutation();
+  const navigate = useNavigate();
+
+  const [session, setSession] = useState<StartSessionRes | null>(null);
+  const [cursor, setCursor] = useState(0);
+  const [correctCount, setCorrectCount] = useState(0);
+  const [errorCount, setErrorCount] = useState(0);
+  const [keyLog, setKeyLog] = useState<KeyLogEntry[]>([]);
+  const [keyIntervals, setKeyIntervals] = useState<number[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [remainingSeconds, setRemainingSeconds] = useState(0);
+  const [defocusCount, setDefocusCount] = useState(0);
+  const [pasteBlocked] = useState(true);
+  const [focusWarning, setFocusWarning] = useState(false);
+
+  const focusRef = useRef<HTMLDivElement | null>(null);
+  const startTimeRef = useRef<number | null>(null);
+  const lastKeyTimeRef = useRef<number | null>(null);
+  const finishedRef = useRef(false);
+
+  const typingTarget = session?.prompt.typingTarget ?? '';
+  const displayText = session?.prompt.displayText ?? 'セッションを開始するとお題が表示されます。';
+
+  const accuracy = useMemo(
+    () => calculateAccuracy(correctCount, correctCount + errorCount),
+    [correctCount, errorCount],
+  );
+  const cpm = useMemo(() => {
+    const timeLimit = contest?.timeLimitSec ?? 60;
+    const elapsed = Math.max(timeLimit - remainingSeconds, 1);
+    return calculateCpm(correctCount, elapsed);
+  }, [correctCount, contest?.timeLimitSec, remainingSeconds]);
+  const wpm = useMemo(() => calculateWpm(cpm), [cpm]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) {
+        setDefocusCount((value) => value + 1);
+        setFocusWarning(true);
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []);
+
+  useEffect(() => {
+    if (contest && !session) {
+      setRemainingSeconds(contest.timeLimitSec);
+    }
+  }, [contest, session]);
+
+  const resetState = (nextSession: StartSessionRes) => {
+    setSession(nextSession);
+    setCursor(0);
+    setCorrectCount(0);
+    setErrorCount(0);
+    setKeyLog([]);
+    setKeyIntervals([]);
+    setIsRunning(true);
+    setHasError(false);
+    setRemainingSeconds(contest?.timeLimitSec ?? 0);
+    setDefocusCount(0);
+    setFocusWarning(false);
+    startTimeRef.current = performance.now();
+    lastKeyTimeRef.current = null;
+    finishedRef.current = false;
+    window.requestAnimationFrame(() => {
+      focusRef.current?.focus();
+    });
+  };
+
+  const handleStartSession = () => {
+    if (!contestId) return;
+    startSession.mutate(contestId, {
+      onSuccess: resetState,
+    });
+  };
+
+  const handleFinish = () => {
+    if (!session || finishedRef.current) {
+      return;
+    }
+    finishedRef.current = true;
+    setIsRunning(false);
+    const now = performance.now();
+    const elapsedSeconds = Math.max(
+      1,
+      Math.min(
+        contest?.timeLimitSec ?? Number.POSITIVE_INFINITY,
+        startTimeRef.current ? (now - startTimeRef.current) / 1000 : contest?.timeLimitSec ?? 1,
+      ),
+    );
+    const totalTyped = correctCount + errorCount;
+    const accuracyValue = calculateAccuracy(correctCount, totalTyped);
+    const cpmValue = calculateCpm(correctCount, elapsedSeconds);
+    const wpmValue = calculateWpm(cpmValue);
+    const score = calculateScore(cpmValue, accuracyValue);
+    const anomalyScore = calculateAnomalyScore(keyIntervals);
+
+    const result: SessionResult = {
+      sessionId: session.sessionId,
+      contestId: session.contestId,
+      cpm: cpmValue,
+      wpm: wpmValue,
+      accuracy: accuracyValue,
+      errors: errorCount,
+      keylog: keyLog,
+      clientFlags: {
+        defocus: defocusCount,
+        pasteBlocked,
+        anomalyScore,
+      },
+      completedAt: new Date().toISOString(),
+      score,
+    };
+
+    finishSession.mutate(result, {
+      onSuccess: () => {
+        navigate(`/result/${session.sessionId}`, { state: { result, contest } });
+      },
+    });
+  };
+
+  useEffect(() => {
+    if (session && cursor >= typingTarget.length && typingTarget.length > 0) {
+      handleFinish();
+    }
+  }, [cursor, session, typingTarget.length]);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!session || !isRunning) return;
+    if (event.isComposing) return;
+
+    const { key, ctrlKey, metaKey, altKey } = event;
+
+    if (ctrlKey || metaKey || altKey) {
+      return;
+    }
+
+    if (key === 'Tab') {
+      event.preventDefault();
+      setDefocusCount((value) => value + 1);
+      setFocusWarning(true);
+      return;
+    }
+
+    if (key === 'Backspace') {
+      event.preventDefault();
+      if (!contest?.allowBackspace) {
+        setHasError(true);
+        setErrorCount((value) => value + 1);
+        return;
+      }
+      if (cursor > 0) {
+        setCursor((value) => value - 1);
+        setCorrectCount((value) => Math.max(value - 1, 0));
+      }
+      return;
+    }
+
+    if (key.length !== 1) {
+      return;
+    }
+
+    if (cursor >= typingTarget.length) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const expectedChar = typingTarget[cursor];
+    const timestamp = performance.now();
+    if (lastKeyTimeRef.current != null) {
+      setKeyIntervals((prev) => [...prev, timestamp - lastKeyTimeRef.current!]);
+    }
+    lastKeyTimeRef.current = timestamp;
+
+    const isCorrect = key === expectedChar;
+    setKeyLog((prev) => [
+      ...prev,
+      {
+        t: startTimeRef.current ? Math.round(timestamp - startTimeRef.current) : 0,
+        k: key,
+        ok: isCorrect,
+      },
+    ]);
+
+    if (isCorrect) {
+      setCursor((value) => value + 1);
+      setCorrectCount((value) => value + 1);
+      setHasError(false);
+    } else {
+      setHasError(true);
+      setErrorCount((value) => value + 1);
+    }
+  };
+
+  const handleFocus = () => {
+    setFocusWarning(false);
+  };
+
+  const handleBlur = () => {
+    setDefocusCount((value) => value + 1);
+    setFocusWarning(true);
+  };
+
+  const allowInput = Boolean(session && isRunning);
+
+  return (
+    <PageContainer
+      title="タイピングプレイ"
+      description={contest ? `${contest.title} - 残り時間 ${remainingSeconds}s` : 'コンテストを選択してください'}
+      actions={
+        <button type="button" className={styles.primaryButton} onClick={handleStartSession}>
+          {session ? '再挑戦' : 'セッション開始'}
+        </button>
+      }
+    >
+      <div className={styles.layout}>
+        <div className={styles.mainColumn}>
+          <div
+            ref={focusRef}
+            className={styles.inputSurface}
+            tabIndex={0}
+            role="application"
+            aria-label="タイピング入力面"
+            onKeyDown={handleKeyDown}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onPaste={(event) => {
+              event.preventDefault();
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+            }}
+          >
+            <TypingCanvas
+              displayText={displayText}
+              typingTarget={typingTarget}
+              cursorIndex={cursor}
+              hasError={hasError}
+            />
+          </div>
+          <div className={styles.panelRow}>
+            <Timer
+              duration={contest?.timeLimitSec ?? 60}
+              isRunning={allowInput}
+              onExpire={handleFinish}
+              onTick={setRemainingSeconds}
+              resetKey={session?.sessionId}
+            />
+            <KeyStats
+              cpm={cpm}
+              wpm={wpm}
+              accuracy={accuracy}
+              errors={errorCount}
+              remainingSeconds={remainingSeconds}
+            />
+          </div>
+          {focusWarning ? (
+            <p className={styles.warning} role="alert">
+              フォーカスが外れました。戻って続行してください。（回数: {defocusCount}）
+            </p>
+          ) : null}
+        </div>
+        <aside className={styles.sidebar}>
+          <LeaderboardWidget contestId={contestId} />
+          <div className={styles.metaBox}>
+            <h2>セッション状態</h2>
+            <dl>
+              <div>
+                <dt>入力可</dt>
+                <dd>{allowInput ? 'はい' : 'いいえ'}</dd>
+              </div>
+              <div>
+                <dt>フォーカス逸脱</dt>
+                <dd>{defocusCount} 回</dd>
+              </div>
+              <div>
+                <dt>ログ記録数</dt>
+                <dd>{keyLog.length}</dd>
+              </div>
+            </dl>
+          </div>
+        </aside>
+      </div>
+    </PageContainer>
+  );
+};

--- a/src/components/layout/PageContainer.module.css
+++ b/src/components/layout/PageContainer.module.css
@@ -1,0 +1,37 @@
+.container {
+  background-color: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 12px 40px rgba(22, 34, 51, 0.08);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.description {
+  margin: 0.25rem 0 0;
+  color: #4d5c6a;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,0 +1,25 @@
+import { PropsWithChildren } from 'react';
+import styles from './PageContainer.module.css';
+
+type PageContainerProps = PropsWithChildren<{
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+}>;
+
+export const PageContainer = ({ title, description, actions, children }: PageContainerProps) => {
+  return (
+    <section className={styles.container} aria-labelledby="page-heading">
+      <header className={styles.header}>
+        <div>
+          <h1 id="page-heading" className={styles.title}>
+            {title}
+          </h1>
+          {description ? <p className={styles.description}>{description}</p> : null}
+        </div>
+        {actions ? <div className={styles.actions}>{actions}</div> : null}
+      </header>
+      <div className={styles.content}>{children}</div>
+    </section>
+  );
+};

--- a/src/components/navigation/NavigationBar.module.css
+++ b/src/components/navigation/NavigationBar.module.css
@@ -1,0 +1,59 @@
+.header {
+  background: linear-gradient(90deg, #22438a, #1b8cd8);
+  color: #ffffff;
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+}
+
+.brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: inherit;
+  text-decoration: none;
+}
+
+.linkList {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.link:hover,
+.link:focus-visible {
+  opacity: 0.85;
+  border-bottom-color: rgba(255, 255, 255, 0.6);
+}
+
+.active {
+  border-bottom-color: #fff;
+}
+
+@media (max-width: 768px) {
+  .inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .linkList {
+    flex-wrap: wrap;
+  }
+}

--- a/src/components/navigation/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar.tsx
@@ -1,0 +1,38 @@
+import { NavLink } from 'react-router-dom';
+import styles from './NavigationBar.module.css';
+
+const links = [
+  { to: '/', label: 'トップ' },
+  { to: '/dashboard', label: 'ダッシュボード' },
+  { to: '/practice', label: '練習' },
+  { to: '/leaderboard/sample-contest', label: 'ランキング' },
+  { to: '/admin', label: '管理コンソール' },
+];
+
+export const NavigationBar = () => {
+  return (
+    <header className={styles.header}>
+      <div className={styles.inner}>
+        <NavLink to="/" className={styles.brand}>
+          Typing Arena
+        </NavLink>
+        <nav aria-label="主要ナビゲーション">
+          <ul className={styles.linkList}>
+            {links.map((link) => (
+              <li key={link.to}>
+                <NavLink
+                  to={link.to}
+                  className={({ isActive }) =>
+                    isActive ? `${styles.link} ${styles.active}` : styles.link
+                  }
+                >
+                  {link.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+};

--- a/src/components/typing/AdminForms.module.css
+++ b/src/components/typing/AdminForms.module.css
@@ -1,0 +1,49 @@
+.adminArea {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d0d7e2;
+  background-color: #f9fbfd;
+}
+
+.form h2 {
+  margin: 0;
+}
+
+.form label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.form input,
+.form textarea,
+.form select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+}
+
+.form button {
+  justify-self: flex-start;
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.6rem;
+  border: none;
+  background: linear-gradient(120deg, #1b8cd8, #1fd1a5);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.checkbox {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 500;
+}

--- a/src/components/typing/AdminForms.tsx
+++ b/src/components/typing/AdminForms.tsx
@@ -1,0 +1,58 @@
+import { FormEvent } from 'react';
+import styles from './AdminForms.module.css';
+
+export const AdminForms = () => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const data = Object.fromEntries(new FormData(form).entries());
+    // 本実装ではAPIへ送信する。
+    console.info('管理フォームの送信', data);
+  };
+
+  return (
+    <section className={styles.adminArea} aria-label="管理フォーム">
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <h2>コンテスト設定</h2>
+        <label>
+          タイトル
+          <input name="title" required />
+        </label>
+        <label>
+          制限時間（秒）
+          <input type="number" name="timeLimit" min={10} max={300} defaultValue={60} />
+        </label>
+        <label>
+          最大試行回数
+          <input type="number" name="maxAttempts" min={0} max={10} defaultValue={3} />
+        </label>
+        <label className={styles.checkbox}>
+          <input type="checkbox" name="allowBackspace" defaultChecked={false} />
+          Backspace を許可する
+        </label>
+        <button type="submit">保存</button>
+      </form>
+
+      <form className={styles.form} onSubmit={handleSubmit}>
+        <h2>プロンプト登録</h2>
+        <label>
+          表示文
+          <textarea name="displayText" required rows={3} />
+        </label>
+        <label>
+          タイプ対象（ローマ字列）
+          <textarea name="typingTarget" required rows={2} />
+        </label>
+        <label>
+          言語
+          <select name="language" defaultValue="romaji">
+            <option value="romaji">ローマ字</option>
+            <option value="english">英語</option>
+            <option value="kana">かな</option>
+          </select>
+        </label>
+        <button type="submit">追加</button>
+      </form>
+    </section>
+  );
+};

--- a/src/components/typing/KeyStats.module.css
+++ b/src/components/typing/KeyStats.module.css
@@ -1,0 +1,20 @@
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  background-color: #f8fafc;
+}
+
+.label {
+  display: block;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.value {
+  font-size: 1.25rem;
+  font-weight: 700;
+}

--- a/src/components/typing/KeyStats.tsx
+++ b/src/components/typing/KeyStats.tsx
@@ -1,0 +1,37 @@
+import styles from './KeyStats.module.css';
+import { formatAccuracy } from '@/lib/keyboard/typingUtils.ts';
+
+type KeyStatsProps = {
+  cpm: number;
+  wpm: number;
+  accuracy: number;
+  errors: number;
+  remainingSeconds: number;
+};
+
+export const KeyStats = ({ cpm, wpm, accuracy, errors, remainingSeconds }: KeyStatsProps) => {
+  return (
+    <section className={styles.stats} aria-label="タイピング統計">
+      <div>
+        <span className={styles.label}>CPM</span>
+        <span className={styles.value}>{cpm}</span>
+      </div>
+      <div>
+        <span className={styles.label}>WPM</span>
+        <span className={styles.value}>{wpm}</span>
+      </div>
+      <div>
+        <span className={styles.label}>正確率</span>
+        <span className={styles.value}>{formatAccuracy(accuracy)}</span>
+      </div>
+      <div>
+        <span className={styles.label}>ミス</span>
+        <span className={styles.value}>{errors}</span>
+      </div>
+      <div>
+        <span className={styles.label}>残り時間</span>
+        <span className={styles.value}>{remainingSeconds}s</span>
+      </div>
+    </section>
+  );
+};

--- a/src/components/typing/LeaderboardWidget.module.css
+++ b/src/components/typing/LeaderboardWidget.module.css
@@ -1,0 +1,61 @@
+.leaderboard {
+  border: 1px solid #d0d7e2;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: #ffffff;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.75rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.caption {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.item {
+  display: grid;
+  grid-template-columns: 2rem 1fr 4rem auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background-color: #f8fafc;
+}
+
+.rank {
+  font-weight: 700;
+  text-align: center;
+}
+
+.user {
+  font-weight: 600;
+}
+
+.score {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.metrics {
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: right;
+}

--- a/src/components/typing/LeaderboardWidget.tsx
+++ b/src/components/typing/LeaderboardWidget.tsx
@@ -1,0 +1,37 @@
+import { useLeaderboardQuery } from '@/features/contest/api/contestQueries.ts';
+import styles from './LeaderboardWidget.module.css';
+
+type LeaderboardWidgetProps = {
+  contestId: string;
+};
+
+export const LeaderboardWidget = ({ contestId }: LeaderboardWidgetProps) => {
+  const { data, isLoading } = useLeaderboardQuery(contestId, Boolean(contestId));
+
+  if (isLoading) {
+    return <p>ランキングを取得しています...</p>;
+  }
+
+  if (!data) {
+    return <p>ランキング情報がありません。</p>;
+  }
+
+  return (
+    <section className={styles.leaderboard} aria-label="暫定ランキング">
+      <header className={styles.header}>
+        <h2>Leaderboard</h2>
+        <span className={styles.caption}>自動更新（5秒間隔）</span>
+      </header>
+      <ol className={styles.list}>
+        {data.top.map((entry) => (
+          <li key={entry.rank} className={styles.item}>
+            <span className={styles.rank}>{entry.rank}</span>
+            <span className={styles.user}>{entry.user}</span>
+            <span className={styles.score}>{entry.score}</span>
+            <span className={styles.metrics}>{entry.cpm}cpm / {(entry.accuracy * 100).toFixed(1)}%</span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};

--- a/src/components/typing/Timer.module.css
+++ b/src/components/typing/Timer.module.css
@@ -1,0 +1,19 @@
+.timer {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
+  background-color: #0f172a;
+  color: #f8fafc;
+  font-weight: 600;
+}
+
+.label {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.value {
+  font-size: 1.2rem;
+}

--- a/src/components/typing/Timer.tsx
+++ b/src/components/typing/Timer.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import styles from './Timer.module.css';
+
+type TimerProps = {
+  duration: number;
+  isRunning: boolean;
+  onExpire: () => void;
+  onTick?: (remaining: number) => void;
+  resetKey?: string | number;
+};
+
+export const Timer = ({ duration, isRunning, onExpire, onTick, resetKey }: TimerProps) => {
+  const [remaining, setRemaining] = useState(duration);
+  const hasExpiredRef = useRef(false);
+
+  useEffect(() => {
+    setRemaining(duration);
+    hasExpiredRef.current = false;
+    onTick?.(duration);
+  }, [duration, resetKey, onTick]);
+
+  useEffect(() => {
+    if (!isRunning || remaining <= 0 || hasExpiredRef.current) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setRemaining((prev) => {
+        const next = prev - 1;
+        onTick?.(Math.max(next, 0));
+        if (next <= 0 && !hasExpiredRef.current) {
+          hasExpiredRef.current = true;
+          onExpire();
+          return 0;
+        }
+        return next;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [isRunning, remaining, onExpire, onTick]);
+
+  return (
+    <div className={styles.timer} role="timer" aria-live="polite">
+      <span className={styles.label}>残り時間</span>
+      <span className={styles.value}>{remaining}s</span>
+    </div>
+  );
+};

--- a/src/components/typing/TypingCanvas.module.css
+++ b/src/components/typing/TypingCanvas.module.css
@@ -1,0 +1,60 @@
+.canvas {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.displayText {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #1f2933;
+}
+
+.target {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: 'Fira Code', 'Roboto Mono', 'SFMono-Regular', monospace;
+  font-size: 1.1rem;
+  min-height: 3.5rem;
+}
+
+.char {
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.1s ease, color 0.1s ease;
+}
+
+.typed {
+  background-color: rgba(34, 197, 94, 0.3);
+  color: #bbf7d0;
+}
+
+.current {
+  background-color: rgba(59, 130, 246, 0.5);
+  color: #e0f2fe;
+  border-bottom: 2px solid #60a5fa;
+}
+
+.error {
+  background-color: rgba(248, 113, 113, 0.6);
+  color: #fee2e2;
+  border-bottom: 2px solid #f87171;
+}
+
+.pending {
+  opacity: 0.65;
+}
+
+.completed {
+  color: #34d399;
+}
+
+.progress {
+  margin: 0;
+  color: #4d5c6a;
+  font-weight: 500;
+}

--- a/src/components/typing/TypingCanvas.tsx
+++ b/src/components/typing/TypingCanvas.tsx
@@ -1,0 +1,47 @@
+import clsx from 'clsx';
+import styles from './TypingCanvas.module.css';
+
+type TypingCanvasProps = {
+  displayText: string;
+  typingTarget: string;
+  cursorIndex: number;
+  hasError: boolean;
+};
+
+export const TypingCanvas = ({ displayText, typingTarget, cursorIndex, hasError }: TypingCanvasProps) => {
+  const characters = typingTarget.split('');
+  const remaining = Math.max(characters.length - cursorIndex, 0);
+
+  return (
+    <div className={styles.canvas}>
+      <p className={styles.displayText} aria-label="表示文">
+        {displayText}
+      </p>
+      <div className={styles.target} aria-live="polite">
+        {characters.map((char, index) => {
+          const isCurrent = index === cursorIndex;
+          const isTyped = index < cursorIndex;
+          const className = clsx(styles.char, {
+            [styles.typed]: isTyped,
+            [styles.current]: isCurrent && !hasError,
+            [styles.error]: isCurrent && hasError,
+            [styles.pending]: !isTyped && !isCurrent,
+          });
+          return (
+            <span key={`${char}-${index}`} className={className} aria-hidden="true">
+              {char}
+            </span>
+          );
+        })}
+        {cursorIndex >= characters.length && characters.length > 0 ? (
+          <span className={clsx(styles.char, styles.completed)} aria-hidden="true">
+            ✓
+          </span>
+        ) : null}
+      </div>
+      <p className={styles.progress} role="status">
+        残り {remaining} 文字
+      </p>
+    </div>
+  );
+};

--- a/src/features/contest/api/contestQueries.ts
+++ b/src/features/contest/api/contestQueries.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import {
+  fetchContest,
+  fetchContests,
+  fetchLeaderboard,
+  finishContestSession,
+  startContestSession,
+} from './mockContestService.ts';
+import { LeaderboardPayload, SessionResult, StartSessionRes } from '@/types/api.ts';
+
+const contestKeys = {
+  all: ['contests'] as const,
+  detail: (contestId: string) => [...contestKeys.all, contestId] as const,
+  leaderboard: (contestId: string) => [...contestKeys.detail(contestId), 'leaderboard'] as const,
+  session: (contestId: string) => [...contestKeys.detail(contestId), 'session'] as const,
+};
+
+type Options<T> = Omit<UseQueryOptions<T, Error, T, ReturnType<typeof contestKeys.all>>, 'queryKey' | 'queryFn'>;
+
+export const useContestsQuery = (options?: Options<Awaited<ReturnType<typeof fetchContests>>>) =>
+  useQuery({
+    queryKey: contestKeys.all,
+    queryFn: fetchContests,
+    staleTime: 60_000,
+    ...options,
+  });
+
+export const useContestQuery = (contestId: string, enabled = true) =>
+  useQuery({
+    queryKey: contestKeys.detail(contestId),
+    queryFn: () => fetchContest(contestId),
+    enabled,
+  });
+
+export const useLeaderboardQuery = (contestId: string, enabled = true) =>
+  useQuery<LeaderboardPayload>({
+    queryKey: contestKeys.leaderboard(contestId),
+    queryFn: () => fetchLeaderboard(contestId),
+    enabled,
+    refetchInterval: 5_000,
+  });
+
+export const useStartSessionMutation = () =>
+  useMutation<StartSessionRes, Error, string>({
+    mutationFn: (contestId: string) => startContestSession(contestId),
+  });
+
+export const useFinishSessionMutation = () =>
+  useMutation<SessionResult, Error, SessionResult>({
+    mutationFn: (payload) => finishContestSession(payload),
+  });

--- a/src/features/contest/api/mockContestService.ts
+++ b/src/features/contest/api/mockContestService.ts
@@ -1,0 +1,192 @@
+import {
+  Contest,
+  LeaderboardEntry,
+  LeaderboardPayload,
+  Prompt,
+  SessionResult,
+  StartSessionRes,
+} from '@/types/api.ts';
+import {
+  calculateAccuracy,
+  calculateCpm,
+  calculateScore,
+  calculateWpm,
+} from '@/lib/keyboard/typingUtils.ts';
+
+const sampleContestId = 'sample-contest';
+
+const withOffset = (offsetSeconds: number) =>
+  new Date(Date.now() + offsetSeconds * 1000).toISOString();
+
+const contests: Contest[] = [
+  {
+    id: sampleContestId,
+    title: '秋の腕試し杯',
+    description: '60秒でベストスコアに挑む公式ルール。',
+    visibility: 'public',
+    startsAt: withOffset(-3600),
+    endsAt: withOffset(86400),
+    timezone: 'Asia/Tokyo',
+    timeLimitSec: 60,
+    maxAttempts: 5,
+    allowBackspace: false,
+    leaderboardVisibility: 'during',
+    language: 'romaji',
+  },
+  {
+    id: 'training-room',
+    title: '英語フレーズ練習会',
+    description: '英単語のフローを鍛える練習モード。',
+    visibility: 'public',
+    startsAt: withOffset(-7200),
+    endsAt: withOffset(604800),
+    timezone: 'Asia/Tokyo',
+    timeLimitSec: 45,
+    maxAttempts: 0,
+    allowBackspace: true,
+    leaderboardVisibility: 'after',
+    language: 'english',
+  },
+];
+
+const promptsByContest: Record<string, Prompt[]> = {
+  [sampleContestId]: [
+    {
+      id: 'prompt-1',
+      displayText: '今日は良い天気ですね',
+      typingTarget: 'kyouhayiitenkidesune',
+    },
+    {
+      id: 'prompt-2',
+      displayText: '集中してリズムよく打ちましょう',
+      typingTarget: 'shuuchuushiterizumuyokuchimashou',
+    },
+  ],
+  'training-room': [
+    {
+      id: 'prompt-en-1',
+      displayText: 'The quick brown fox jumps over the lazy dog.',
+      typingTarget: 'thequickbrownfoxjumpsoverthelazydog',
+    },
+  ],
+};
+
+const leaderboardStore: Record<string, LeaderboardEntry[]> = {
+  [sampleContestId]: [
+    { rank: 1, user: 'alice', score: 930, cpm: 360, accuracy: 0.99 },
+    { rank: 2, user: 'bob', score: 880, cpm: 340, accuracy: 0.97 },
+  ],
+};
+
+const delay = (ms = 200) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const pickPrompt = (contestId: string): Prompt => {
+  const prompts = promptsByContest[contestId] ?? promptsByContest[sampleContestId];
+  const index = Math.floor(Math.random() * prompts.length);
+  return prompts[index];
+};
+
+const generateId = () => Math.random().toString(36).slice(2, 10);
+
+export const fetchContests = async (): Promise<Contest[]> => {
+  await delay();
+  return contests;
+};
+
+export const fetchContest = async (contestId: string): Promise<Contest | undefined> => {
+  await delay();
+  return contests.find((contest) => contest.id === contestId);
+};
+
+export const fetchLeaderboard = async (
+  contestId: string,
+): Promise<LeaderboardPayload> => {
+  await delay();
+  const entries = leaderboardStore[contestId] ?? [];
+  return {
+    top: entries
+      .map((entry, index) => ({ ...entry, rank: index + 1 }))
+      .slice(0, 10),
+    me: undefined,
+  };
+};
+
+export const startContestSession = async (
+  contestId: string,
+): Promise<StartSessionRes> => {
+  await delay();
+  const contest = await fetchContest(contestId);
+  const prompt = pickPrompt(contest?.id ?? sampleContestId);
+  return {
+    sessionId: generateId(),
+    contestId: contest?.id ?? sampleContestId,
+    prompt,
+    startedAt: new Date().toISOString(),
+  };
+};
+
+export const finishContestSession = async (
+  session: SessionResult,
+): Promise<SessionResult> => {
+  await delay();
+  const { contestId } = session;
+  const entries = leaderboardStore[contestId] ?? [];
+  const nextEntries = [...entries, session].map<LeaderboardEntry>((item, index) => ({
+    rank: index + 1,
+    user: index === entries.length ? 'you' : item.user,
+    score: item.score,
+    cpm: item.cpm,
+    accuracy: item.accuracy,
+  }));
+
+  nextEntries.sort((a, b) => {
+    if (a.score === b.score) {
+      if (a.accuracy === b.accuracy) {
+        return b.cpm - a.cpm;
+      }
+      return b.accuracy - a.accuracy;
+    }
+    return b.score - a.score;
+  });
+
+  leaderboardStore[contestId] = nextEntries.map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+  }));
+
+  return session;
+};
+
+export const buildSessionResult = (
+  session: StartSessionRes,
+  keyCount: number,
+  correctCount: number,
+  errorCount: number,
+  durationSec: number,
+  keylogCount: number,
+): SessionResult => {
+  const accuracy = calculateAccuracy(correctCount, correctCount + errorCount);
+  const cpm = calculateCpm(correctCount, durationSec);
+  const wpm = calculateWpm(cpm);
+  const score = calculateScore(cpm, accuracy);
+  return {
+    sessionId: session.sessionId,
+    contestId: session.contestId,
+    cpm,
+    wpm,
+    accuracy,
+    errors: errorCount,
+    keylog: new Array(keylogCount).fill(null).map((_, index) => ({
+      t: index * 120,
+      k: '.',
+      ok: true,
+    })),
+    clientFlags: {
+      defocus: 0,
+      pasteBlocked: true,
+      anomalyScore: Math.max(0, 1 - keyCount / Math.max(durationSec, 1) / 10),
+    },
+    completedAt: new Date().toISOString(),
+    score,
+  };
+};

--- a/src/lib/keyboard/typingUtils.ts
+++ b/src/lib/keyboard/typingUtils.ts
@@ -1,0 +1,45 @@
+export const calculateAccuracy = (correct: number, total: number) => {
+  if (total <= 0) return 1;
+  return Math.min(1, Math.max(0, correct / total));
+};
+
+export const calculateCpm = (correct: number, durationSec: number) => {
+  if (durationSec <= 0) return 0;
+  return Math.round((correct / durationSec) * 60);
+};
+
+export const calculateWpm = (cpm: number) => Math.round(cpm / 5);
+
+export const calculateScore = (cpm: number, accuracy: number) =>
+  Math.floor(cpm * Math.pow(accuracy, 2) / 2);
+
+export const formatAccuracy = (accuracy: number) => `${(accuracy * 100).toFixed(1)}%`;
+
+export const formatSpeed = (value: number) => `${value.toLocaleString()} cpm`;
+
+export const sanitizeKey = (key: string) => {
+  if (key.length === 1) {
+    return key;
+  }
+  switch (key) {
+    case ' ': {
+      return ' ';
+    }
+    case 'Tab':
+      return '\t';
+    default:
+      return key;
+  }
+};
+
+export const calculateAnomalyScore = (intervals: number[]) => {
+  if (intervals.length < 2) {
+    return 0;
+  }
+  const avg = intervals.reduce((sum, value) => sum + value, 0) / intervals.length;
+  const variance =
+    intervals.reduce((sum, value) => sum + Math.pow(value - avg, 2), 0) / intervals.length;
+  const std = Math.sqrt(variance);
+  const coefficient = avg === 0 ? 0 : std / avg;
+  return Number((1 - Math.min(coefficient, 1)).toFixed(2));
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './app/App.tsx';
+import './styles/global.css';
+
+const queryClient = new QueryClient();
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('アプリケーションのマウント先が見つかりません');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,44 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', 'Hiragino Sans', 'Noto Sans JP', system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+main {
+  min-height: calc(100vh - 4rem);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,71 @@
+export type ContestVisibility = 'public' | 'private';
+export type LeaderboardVisibility = 'during' | 'after' | 'hidden';
+export type ContestLanguage = 'romaji' | 'english' | 'kana';
+
+export type Contest = {
+  id: string;
+  title: string;
+  description?: string;
+  visibility: ContestVisibility;
+  joinCode?: string;
+  startsAt: string;
+  endsAt: string;
+  timezone: 'Asia/Tokyo';
+  timeLimitSec: number;
+  maxAttempts: number;
+  allowBackspace: boolean;
+  leaderboardVisibility: LeaderboardVisibility;
+  language: ContestLanguage;
+};
+
+export type Prompt = {
+  id: string;
+  displayText: string;
+  typingTarget: string;
+};
+
+export type StartSessionRes = {
+  sessionId: string;
+  contestId: string;
+  prompt: Prompt;
+  startedAt: string;
+};
+
+export type KeyLogEntry = {
+  t: number;
+  k: string;
+  ok: boolean;
+};
+
+export type FinishSessionReq = {
+  cpm: number;
+  wpm: number;
+  accuracy: number;
+  errors: number;
+  keylog: KeyLogEntry[];
+  clientFlags?: {
+    defocus: number;
+    pasteBlocked: boolean;
+    anomalyScore?: number;
+  };
+};
+
+export type SessionResult = FinishSessionReq & {
+  sessionId: string;
+  contestId: string;
+  completedAt: string;
+  score: number;
+};
+
+export type LeaderboardEntry = {
+  rank: number;
+  user: string;
+  score: number;
+  cpm: number;
+  accuracy: number;
+};
+
+export type LeaderboardPayload = {
+  top: LeaderboardEntry[];
+  me?: LeaderboardEntry | null;
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "useDefineForClassFields": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- React 18 + Vite + TypeScript ベースのフロントエンドひな型を追加
- 主要画面コンポーネントとモックAPI、タイピング用コンポーネントを実装
- ESLint/TSConfig 設定や共通レイアウト、スタイルを整備

## Testing
- npm install *(失敗: npm registry 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ceacc4df808323aeed0907d2c03a65