### PR TITLE
ナビゲーションのランキングリンクをコンテストUUIDに対応

### DIFF
--- a/src/components/navigation/NavigationBar.module.css
+++ b/src/components/navigation/NavigationBar.module.css
@@ -46,6 +46,11 @@
   border-bottom-color: #fff;
 }
 
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 @media (max-width: 768px) {
   .inner {
     flex-direction: column;

--- a/src/components/navigation/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar.tsx
@@ -1,15 +1,31 @@
 import { NavLink } from 'react-router-dom';
+import { useContestsQuery } from '@/features/contest/api/contestQueries.ts';
 import styles from './NavigationBar.module.css';
 
-const links = [
-  { to: '/', label: 'トップ' },
-  { to: '/dashboard', label: 'ダッシュボード' },
-  { to: '/practice', label: '練習' },
-  { to: '/leaderboard/sample-contest', label: 'ランキング' },
-  { to: '/admin', label: '管理コンソール' },
+type NavigationItem = {
+  key: string;
+  label: string;
+  to?: string;
+};
+
+const staticLinks: NavigationItem[] = [
+  { key: 'home', to: '/', label: 'トップ' },
+  { key: 'dashboard', to: '/dashboard', label: 'ダッシュボード' },
+  { key: 'practice', to: '/practice', label: '練習' },
+  { key: 'admin', to: '/admin', label: '管理コンソール' },
 ];
 
 export const NavigationBar = () => {
+  const { data: contests } = useContestsQuery();
+  const leaderboardContestId = contests?.[0]?.id;
+
+  const leaderboardLink: NavigationItem = leaderboardContestId
+    ? { key: 'leaderboard', to: `/leaderboard/${leaderboardContestId}`, label: 'ランキング' }
+    : { key: 'leaderboard', label: 'ランキング' };
+
+  const links: NavigationItem[] = [...staticLinks];
+  links.splice(3, 0, leaderboardLink);
+
   return (
     <header className={styles.header}>
       <div className={styles.inner}>
@@ -19,15 +35,21 @@ export const NavigationBar = () => {
         <nav aria-label="主要ナビゲーション">
           <ul className={styles.linkList}>
             {links.map((link) => (
-              <li key={link.to}>
-                <NavLink
-                  to={link.to}
-                  className={({ isActive }) =>
-                    isActive ? `${styles.link} ${styles.active}` : styles.link
-                  }
-                >
-                  {link.label}
-                </NavLink>
+              <li key={link.key}>
+                {link.to ? (
+                  <NavLink
+                    to={link.to}
+                    className={({ isActive }) =>
+                      isActive ? `${styles.link} ${styles.active}` : styles.link
+                    }
+                  >
+                    {link.label}
+                  </NavLink>
+                ) : (
+                  <span className={`${styles.link} ${styles.disabled}`} aria-disabled="true">
+                    {link.label}
+                  </span>
+                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- ナビゲーションバーでコンテスト一覧から取得したUUIDを使ってランキングリンクを生成
- コンテスト情報が未取得の間はランキングリンクを非活性表示するスタイルを追加

## Testing
- npm run lint *(biome コマンドが環境に存在せず失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68cee2aa03fc83238bce83919fdf08c3