### PR TITLE
Show guidance when no contests available

### DIFF
--- a/src/app/routes/Dashboard.tsx
+++ b/src/app/routes/Dashboard.tsx
@@ -14,6 +14,11 @@ export const Dashboard = () => {
       <section aria-label="コンテスト一覧" className={styles.contestList}>
         {isLoading ? <p>読み込み中...</p> : null}
         {error ? <p role="alert">コンテスト一覧の取得に失敗しました。</p> : null}
+        {!isLoading && !error && (!data || data.length === 0) ? (
+          <p>
+            現在、参加可能なコンテストがありません。バックエンドが起動しているか確認し、管理者の方は管理コンソールから新しいコンテストを作成して再度読み込んでください。
+          </p>
+        ) : null}
         {data?.map((contest) => (
           <article key={contest.id} className={styles.card}>
             <h2>{contest.title}</h2>


### PR DESCRIPTION
## Summary
- コンテスト一覧が読み込み済みかつエラーがない場合に、利用可能なコンテストが存在しない旨の案内文を表示

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee8e371d883239d294f518d79b1d0