### PR TITLE
ログイン状態の表示とログアウト導線を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
 *.log
 .DS_Store
 

--- a/src/app/routes/Landing.module.css
+++ b/src/app/routes/Landing.module.css
@@ -36,6 +36,38 @@
   font-weight: 600;
 }
 
+.loggedInMessage {
+  margin: 0;
+  font-weight: 600;
+  color: #1b8cd8;
+}
+
+.logoutButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid #1b8cd8;
+  background-color: #ffffff;
+  color: #1b8cd8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.logoutButton:hover,
+.logoutButton:focus-visible {
+  transform: translateY(-2px);
+  opacity: 0.85;
+}
+
+.logoutButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
 .featureGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/src/app/routes/Landing.tsx
+++ b/src/app/routes/Landing.tsx
@@ -1,21 +1,34 @@
 import { Link } from 'react-router-dom';
 import { PageContainer } from '@/components/layout/PageContainer.tsx';
+import { LogoutButton } from '@/features/auth/components/LogoutButton.tsx';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
 import styles from './Landing.module.css';
 
 export const Landing = () => {
+  const { user } = useAuth();
+
   return (
     <PageContainer
       title="Typing Arena"
       description="e-typingの緊張感と分析機能を備えたモダンなタイピング学習・競技プラットフォーム"
       actions={
-        <div className={styles.actions}>
-          <Link className={styles.primaryCta} to="/signup">
-            今すぐ無料で始める
-          </Link>
-          <Link className={styles.secondaryCta} to="/signin">
-            ログイン
-          </Link>
-        </div>
+        user ? (
+          <div className={styles.actions}>
+            <p className={styles.loggedInMessage} aria-live="polite">
+              {user.username}さんとしてログイン中
+            </p>
+            <LogoutButton className={styles.logoutButton} />
+          </div>
+        ) : (
+          <div className={styles.actions}>
+            <Link className={styles.primaryCta} to="/signup">
+              今すぐ無料で始める
+            </Link>
+            <Link className={styles.secondaryCta} to="/signin">
+              ログイン
+            </Link>
+          </div>
+        )
       }
     >
       <section className={styles.featureGrid} aria-label="主な特徴">

--- a/src/app/routes/SignIn.tsx
+++ b/src/app/routes/SignIn.tsx
@@ -2,13 +2,14 @@ import { type FormEvent, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { PageContainer } from '@/components/layout/PageContainer.tsx';
 import { useSignInMutation } from '@/features/auth/api/authQueries.ts';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
 import { setAccessToken } from '@/lib/apiClient.ts';
-import { storeAuthUser } from '@/lib/authStorage.ts';
 import styles from './Auth.module.css';
 
 export const SignIn = () => {
   const navigate = useNavigate();
   const signIn = useSignInMutation();
+  const { setUser } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [agreed, setAgreed] = useState(false);
@@ -26,7 +27,7 @@ export const SignIn = () => {
       {
         onSuccess: (data) => {
           setAccessToken(data.accessToken);
-          storeAuthUser(data.user);
+          setUser(data.user);
           setFeedback({ type: 'success', message: 'ログインに成功しました。ダッシュボードへ移動します。' });
           navigate('/dashboard');
         },

--- a/src/app/routes/SignUp.tsx
+++ b/src/app/routes/SignUp.tsx
@@ -2,13 +2,14 @@ import { type FormEvent, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { PageContainer } from '@/components/layout/PageContainer.tsx';
 import { useSignUpMutation } from '@/features/auth/api/authQueries.ts';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
 import { setAccessToken } from '@/lib/apiClient.ts';
-import { storeAuthUser } from '@/lib/authStorage.ts';
 import styles from './Auth.module.css';
 
 export const SignUp = () => {
   const navigate = useNavigate();
   const signUp = useSignUpMutation();
+  const { setUser } = useAuth();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -27,7 +28,7 @@ export const SignUp = () => {
       {
         onSuccess: (data) => {
           setAccessToken(data.accessToken);
-          storeAuthUser(data.user);
+          setUser(data.user);
           setFeedback({ type: 'success', message: 'アカウント登録が完了しました。ダッシュボードへ移動します。' });
           navigate('/dashboard');
         },

--- a/src/components/navigation/NavigationBar.module.css
+++ b/src/components/navigation/NavigationBar.module.css
@@ -10,6 +10,7 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 0.75rem 1rem;
+  gap: 1rem;
 }
 
 .brand {
@@ -17,6 +18,12 @@
   font-weight: 700;
   color: inherit;
   text-decoration: none;
+}
+
+.nav {
+  flex: 1;
+  display: flex;
+  justify-content: center;
 }
 
 .linkList {
@@ -51,6 +58,87 @@
   cursor: not-allowed;
 }
 
+.authArea {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.userBadge {
+  font-size: 0.875rem;
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+}
+
+.authLinks {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.authLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.authLink:hover,
+.authLink:focus-visible {
+  opacity: 0.85;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.authLinkPrimary {
+  background-color: #ffffff;
+  border-color: #ffffff;
+  color: #1b8cd8;
+}
+
+.authLinkPrimary:hover,
+.authLinkPrimary:focus-visible {
+  color: #1b8cd8;
+  opacity: 0.9;
+  background-color: #ffffff;
+}
+
+.authLinkActive {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+.logoutButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.logoutButton:hover,
+.logoutButton:focus-visible {
+  background-color: rgba(255, 255, 255, 0.2);
+  opacity: 0.85;
+}
+
+.logoutButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
 @media (max-width: 768px) {
   .inner {
     flex-direction: column;
@@ -58,7 +146,28 @@
     gap: 0.75rem;
   }
 
+  .nav {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
   .linkList {
     flex-wrap: wrap;
+  }
+
+  .authArea {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .authLinks {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .userBadge {
+    margin-right: auto;
   }
 }

--- a/src/components/navigation/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar.tsx
@@ -1,4 +1,6 @@
 import { NavLink } from 'react-router-dom';
+import { LogoutButton } from '@/features/auth/components/LogoutButton.tsx';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
 import { useContestsQuery } from '@/features/contest/api/contestQueries.ts';
 import styles from './NavigationBar.module.css';
 
@@ -18,6 +20,7 @@ const staticLinks: NavigationItem[] = [
 export const NavigationBar = () => {
   const { data: contests } = useContestsQuery();
   const leaderboardContestId = contests?.[0]?.id;
+  const { user } = useAuth();
 
   const leaderboardLink: NavigationItem = leaderboardContestId
     ? { key: 'leaderboard', to: `/leaderboard/${leaderboardContestId}`, label: 'ランキング' }
@@ -32,7 +35,7 @@ export const NavigationBar = () => {
         <NavLink to="/" className={styles.brand}>
           Typing Arena
         </NavLink>
-        <nav aria-label="主要ナビゲーション">
+        <nav className={styles.nav} aria-label="主要ナビゲーション">
           <ul className={styles.linkList}>
             {links.map((link) => (
               <li key={link.key}>
@@ -54,6 +57,37 @@ export const NavigationBar = () => {
             ))}
           </ul>
         </nav>
+        <div className={styles.authArea}>
+          {user ? (
+            <>
+              <span className={styles.userBadge} aria-live="polite">
+                {user.username}さんとしてログイン中
+              </span>
+              <LogoutButton className={styles.logoutButton} />
+            </>
+          ) : (
+            <div className={styles.authLinks}>
+              <NavLink
+                to="/signin"
+                className={({ isActive }) =>
+                  isActive ? `${styles.authLink} ${styles.authLinkActive}` : styles.authLink
+                }
+              >
+                ログイン
+              </NavLink>
+              <NavLink
+                to="/signup"
+                className={({ isActive }) =>
+                  isActive
+                    ? `${styles.authLink} ${styles.authLinkPrimary} ${styles.authLinkActive}`
+                    : `${styles.authLink} ${styles.authLinkPrimary}`
+                }
+              >
+                新規登録
+              </NavLink>
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/src/features/auth/components/LogoutButton.tsx
+++ b/src/features/auth/components/LogoutButton.tsx
@@ -1,0 +1,44 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { useSignOutMutation } from '@/features/auth/api/authQueries.ts';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
+import { clearAccessToken } from '@/lib/apiClient.ts';
+
+type LogoutButtonProps = {
+  label?: string;
+  pendingLabel?: string;
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'onClick'>;
+
+export const LogoutButton = ({
+  label = 'ログアウト',
+  pendingLabel = 'ログアウト中...',
+  className,
+  disabled,
+  ...rest
+}: LogoutButtonProps) => {
+  const { clearUser } = useAuth();
+  const signOut = useSignOutMutation();
+
+  const handleClick = () => {
+    signOut.mutate(undefined, {
+      onError: (error) => {
+        console.error('ログアウトに失敗しました', error);
+      },
+      onSettled: () => {
+        clearAccessToken();
+        clearUser();
+      },
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={handleClick}
+      disabled={disabled || signOut.isPending}
+      {...rest}
+    >
+      {signOut.isPending ? pendingLabel : label}
+    </button>
+  );
+};

--- a/src/features/auth/contexts/AuthContext.tsx
+++ b/src/features/auth/contexts/AuthContext.tsx
@@ -1,0 +1,76 @@
+import {
+  type PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  AUTH_USER_STORAGE_KEY,
+  clearAuthUser,
+  loadAuthUser,
+  storeAuthUser,
+} from '@/lib/authStorage.ts';
+import type { AuthUser } from '@/types/api.ts';
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  setUser: (user: AuthUser) => void;
+  clearUser: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: PropsWithChildren): JSX.Element => {
+  const [user, setUserState] = useState<AuthUser | null>(() => loadAuthUser());
+
+  const setUser = useCallback((nextUser: AuthUser) => {
+    storeAuthUser(nextUser);
+    setUserState(nextUser);
+  }, []);
+
+  const clearUser = useCallback(() => {
+    clearAuthUser();
+    setUserState(null);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== AUTH_USER_STORAGE_KEY) {
+        return;
+      }
+      setUserState(loadAuthUser());
+    };
+
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      setUser,
+      clearUser,
+    }),
+    [user, setUser, clearUser],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth は AuthProvider の内部でのみ使用してください');
+  }
+  return context;
+};

--- a/src/lib/authStorage.ts
+++ b/src/lib/authStorage.ts
@@ -1,6 +1,8 @@
 import type { AuthUser } from '@/types/api.ts';
 
-const AUTH_USER_KEY = 'typingArenaAuthUser';
+export const AUTH_USER_STORAGE_KEY = 'typingArenaAuthUser';
+
+const AUTH_USER_KEY = AUTH_USER_STORAGE_KEY;
 
 export const storeAuthUser = (user: AuthUser) => {
   if (typeof window === 'undefined') return;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import App from './app/App';
+import { AuthProvider } from '@/features/auth/contexts/AuthContext.tsx';
 import './styles/global.css';
 
 const queryClient = new QueryClient();
@@ -16,9 +17,11 @@ if (!rootElement) {
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- 認証コンテキストを追加し、ログインユーザー情報を全体で参照できるようにしました
- ナビゲーションバーとランディングページでログイン状態とログアウトボタンを表示するように更新しました
- ログアウトボタンコンポーネントを実装し、サインアウト処理を共通化しました

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceea0322d483239f65f7b5d0e683ea