### PR TITLE
feat: submit admin forms to API

### DIFF
--- a/src/components/typing/AdminForms.module.css
+++ b/src/components/typing/AdminForms.module.css
@@ -50,3 +50,16 @@
 .checkbox input {
   margin-top: 0.4rem;
 }
+
+.feedback {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.feedbackSuccess {
+  color: #047857;
+}
+
+.feedbackError {
+  color: #dc2626;
+}

--- a/src/components/typing/AdminForms.tsx
+++ b/src/components/typing/AdminForms.tsx
@@ -1,18 +1,86 @@
-import type { FormEvent } from 'react';
+import { type FormEvent, useState } from 'react';
+import { useCreateContestMutation, useCreatePromptMutation } from '@/features/admin/api/adminQueries.ts';
+import type { ContestLanguage } from '@/types/api.ts';
 import styles from './AdminForms.module.css';
 
+type Feedback = { type: 'success' | 'error'; message: string };
+
+const parseNumberField = (value: FormDataEntryValue | null) => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') {
+      return 0;
+    }
+    const parsed = Number(trimmed);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+};
+
 export const AdminForms = () => {
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const createContest = useCreateContestMutation();
+  const createPrompt = useCreatePromptMutation();
+  const [contestFeedback, setContestFeedback] = useState<Feedback | null>(null);
+  const [promptFeedback, setPromptFeedback] = useState<Feedback | null>(null);
+
+  const handleContestSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const form = event.currentTarget;
-    const data = Object.fromEntries(new FormData(form).entries());
-    // 本実装ではAPIへ送信する。
-    console.info('管理フォームの送信', data);
+    const formData = new FormData(form);
+    const title = String(formData.get('title') ?? '').trim();
+    const timeLimitSec = parseNumberField(formData.get('timeLimit'));
+    const maxAttempts = parseNumberField(formData.get('maxAttempts'));
+    const allowBackspace = formData.get('allowBackspace') === 'on';
+
+    setContestFeedback(null);
+
+    createContest.mutate(
+      { title, timeLimitSec, maxAttempts, allowBackspace },
+      {
+        onSuccess: () => {
+          setContestFeedback({ type: 'success', message: 'コンテストを保存しました。' });
+          form.reset();
+        },
+        onError: (error) => {
+          setContestFeedback({
+            type: 'error',
+            message: error.message ?? 'コンテストの保存に失敗しました。',
+          });
+        },
+      },
+    );
+  };
+
+  const handlePromptSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const displayText = String(formData.get('displayText') ?? '').trim();
+    const typingTarget = String(formData.get('typingTarget') ?? '').trim();
+    const language = String(formData.get('language') ?? 'romaji') as ContestLanguage;
+
+    setPromptFeedback(null);
+
+    createPrompt.mutate(
+      { displayText, typingTarget, language },
+      {
+        onSuccess: () => {
+          setPromptFeedback({ type: 'success', message: 'プロンプトを追加しました。' });
+          form.reset();
+        },
+        onError: (error) => {
+          setPromptFeedback({
+            type: 'error',
+            message: error.message ?? 'プロンプトの追加に失敗しました。',
+          });
+        },
+      },
+    );
   };
 
   return (
     <section className={styles.adminArea} aria-label="管理フォーム">
-      <form className={styles.form} onSubmit={handleSubmit}>
+      <form className={styles.form} onSubmit={handleContestSubmit}>
         <h2>コンテスト設定</h2>
         <label>
           タイトル
@@ -32,14 +100,23 @@ export const AdminForms = () => {
             type="checkbox"
             name="allowBackspace"
             defaultChecked={false}
-            required
           />
           <label htmlFor="agree">Backspace を許可する</label>
         </div>
-        <button type="submit">保存</button>
+        <button type="submit" disabled={createContest.isPending}>
+          {createContest.isPending ? '送信中...' : '保存'}
+        </button>
+        {contestFeedback ? (
+          <p
+            className={`${styles.feedback} ${contestFeedback.type === 'error' ? styles.feedbackError : styles.feedbackSuccess}`}
+            role={contestFeedback.type === 'error' ? 'alert' : 'status'}
+          >
+            {contestFeedback.message}
+          </p>
+        ) : null}
       </form>
 
-      <form className={styles.form} onSubmit={handleSubmit}>
+      <form className={styles.form} onSubmit={handlePromptSubmit}>
         <h2>プロンプト登録</h2>
         <label>
           表示文
@@ -57,7 +134,17 @@ export const AdminForms = () => {
             <option value="kana">かな</option>
           </select>
         </label>
-        <button type="submit">追加</button>
+        <button type="submit" disabled={createPrompt.isPending}>
+          {createPrompt.isPending ? '送信中...' : '追加'}
+        </button>
+        {promptFeedback ? (
+          <p
+            className={`${styles.feedback} ${promptFeedback.type === 'error' ? styles.feedbackError : styles.feedbackSuccess}`}
+            role={promptFeedback.type === 'error' ? 'alert' : 'status'}
+          >
+            {promptFeedback.message}
+          </p>
+        ) : null}
       </form>
     </section>
   );

--- a/src/features/admin/api/adminQueries.ts
+++ b/src/features/admin/api/adminQueries.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { createContest, createPrompt } from './adminService.ts';
+import type {
+  Contest,
+  CreateContestPayload,
+  CreatePromptPayload,
+  Prompt,
+} from '@/types/api.ts';
+
+export const useCreateContestMutation = () =>
+  useMutation<Contest, Error, CreateContestPayload>({
+    mutationFn: createContest,
+  });
+
+export const useCreatePromptMutation = () =>
+  useMutation<Prompt, Error, CreatePromptPayload>({
+    mutationFn: createPrompt,
+  });

--- a/src/features/admin/api/adminService.ts
+++ b/src/features/admin/api/adminService.ts
@@ -1,0 +1,15 @@
+import { apiClient } from '@/lib/apiClient.ts';
+import type {
+  Contest,
+  CreateContestPayload,
+  CreatePromptPayload,
+  Prompt,
+} from '@/types/api.ts';
+
+export const createContest = async (payload: CreateContestPayload): Promise<Contest> => {
+  return apiClient.post<Contest>('/contests', payload);
+};
+
+export const createPrompt = async (payload: CreatePromptPayload): Promise<Prompt> => {
+  return apiClient.post<Prompt>('/prompts', payload);
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -94,3 +94,16 @@ export type SignUpPayload = SignInPayload & {
 export type PasswordResetPayload = {
   email: string;
 };
+
+export type CreateContestPayload = {
+  title: string;
+  timeLimitSec: number;
+  maxAttempts: number;
+  allowBackspace: boolean;
+};
+
+export type CreatePromptPayload = {
+  displayText: string;
+  typingTarget: string;
+  language: ContestLanguage;
+};


### PR DESCRIPTION
## Summary
- add admin API services and mutations for contest and prompt creation
- wire the admin console forms to submit payloads via the API with user feedback
- extend shared types and styling to support the new API workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef3174b208323980efc5c19bd498f