### PR TITLE
コンテスト作成フォームの必須項目を追加

### DIFF
--- a/src/components/typing/AdminForms.tsx
+++ b/src/components/typing/AdminForms.tsx
@@ -1,6 +1,10 @@
-import { type FormEvent, useState } from 'react';
+import { type ChangeEvent, type FormEvent, useState } from 'react';
 import { useCreateContestMutation, useCreatePromptMutation } from '@/features/admin/api/adminQueries.ts';
-import type { ContestLanguage } from '@/types/api.ts';
+import type {
+  ContestLanguage,
+  ContestVisibility,
+  LeaderboardVisibility,
+} from '@/types/api.ts';
 import styles from './AdminForms.module.css';
 
 type Feedback = { type: 'success' | 'error'; message: string };
@@ -17,29 +21,85 @@ const parseNumberField = (value: FormDataEntryValue | null) => {
   return 0;
 };
 
+const parseDateTimeField = (value: FormDataEntryValue | null) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return '';
+  }
+  return parsed.toISOString();
+};
+
 export const AdminForms = () => {
   const createContest = useCreateContestMutation();
   const createPrompt = useCreatePromptMutation();
   const [contestFeedback, setContestFeedback] = useState<Feedback | null>(null);
   const [promptFeedback, setPromptFeedback] = useState<Feedback | null>(null);
+  const [contestVisibility, setContestVisibility] = useState<ContestVisibility>('public');
+
+  const handleVisibilityChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setContestVisibility(event.target.value as ContestVisibility);
+  };
 
   const handleContestSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const form = event.currentTarget;
     const formData = new FormData(form);
     const title = String(formData.get('title') ?? '').trim();
+    const description = String(formData.get('description') ?? '').trim();
+    const visibility = String(formData.get('visibility') ?? 'public') as ContestVisibility;
+    const joinCode = String(formData.get('joinCode') ?? '').trim();
+    const startsAt = parseDateTimeField(formData.get('startsAt'));
+    const endsAt = parseDateTimeField(formData.get('endsAt'));
+    const leaderboardVisibility = String(
+      formData.get('leaderboardVisibility') ?? 'during',
+    ) as LeaderboardVisibility;
+    const language = String(formData.get('language') ?? 'romaji') as ContestLanguage;
     const timeLimitSec = parseNumberField(formData.get('timeLimit'));
     const maxAttempts = parseNumberField(formData.get('maxAttempts'));
     const allowBackspace = formData.get('allowBackspace') === 'on';
 
     setContestFeedback(null);
 
+    if (!startsAt) {
+      setContestFeedback({ type: 'error', message: '開始日時を正しく入力してください。' });
+      return;
+    }
+    if (!endsAt) {
+      setContestFeedback({ type: 'error', message: '終了日時を正しく入力してください。' });
+      return;
+    }
+    if (new Date(endsAt).getTime() <= new Date(startsAt).getTime()) {
+      setContestFeedback({ type: 'error', message: '終了日時は開始日時より後に設定してください。' });
+      return;
+    }
+
     createContest.mutate(
-      { title, timeLimitSec, maxAttempts, allowBackspace },
+      {
+        title,
+        description: description === '' ? undefined : description,
+        visibility,
+        joinCode: joinCode === '' ? undefined : joinCode,
+        startsAt,
+        endsAt,
+        timezone: 'Asia/Tokyo',
+        timeLimitSec,
+        maxAttempts,
+        allowBackspace,
+        leaderboardVisibility,
+        language,
+      },
       {
         onSuccess: () => {
           setContestFeedback({ type: 'success', message: 'コンテストを保存しました。' });
           form.reset();
+          setContestVisibility('public');
         },
         onError: (error) => {
           setContestFeedback({
@@ -85,6 +145,53 @@ export const AdminForms = () => {
         <label>
           タイトル
           <input name="title" required />
+        </label>
+        <label>
+          説明
+          <textarea name="description" rows={3} />
+        </label>
+        <label>
+          公開設定
+          <select
+            name="visibility"
+            defaultValue="public"
+            onChange={handleVisibilityChange}
+          >
+            <option value="public">公開</option>
+            <option value="private">非公開</option>
+          </select>
+        </label>
+        <label>
+          参加コード
+          <input
+            name="joinCode"
+            placeholder="非公開コンテストで使用"
+            disabled={contestVisibility !== 'private'}
+          />
+        </label>
+        <label>
+          開始日時
+          <input type="datetime-local" name="startsAt" required />
+        </label>
+        <label>
+          終了日時
+          <input type="datetime-local" name="endsAt" required />
+        </label>
+        <label>
+          ランキング公開
+          <select name="leaderboardVisibility" defaultValue="during">
+            <option value="during">期間中公開</option>
+            <option value="after">終了後公開</option>
+            <option value="hidden">非公開</option>
+          </select>
+        </label>
+        <label>
+          言語
+          <select name="language" defaultValue="romaji">
+            <option value="romaji">ローマ字</option>
+            <option value="english">英語</option>
+            <option value="kana">かな</option>
+          </select>
         </label>
         <label>
           制限時間（秒）

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -97,9 +97,17 @@ export type PasswordResetPayload = {
 
 export type CreateContestPayload = {
   title: string;
+  description?: string;
+  visibility: ContestVisibility;
+  joinCode?: string;
+  startsAt: string;
+  endsAt: string;
+  timezone: 'Asia/Tokyo';
   timeLimitSec: number;
   maxAttempts: number;
   allowBackspace: boolean;
+  leaderboardVisibility: LeaderboardVisibility;
+  language: ContestLanguage;
 };
 
 export type CreatePromptPayload = {


### PR DESCRIPTION
## Summary
- コンテスト作成フォームに公開設定・期間・言語などの入力欄を追加し、送信時のバリデーションを実装しました
- CreateContestPayload をバックエンドの必須フィールドに合わせて拡張しました

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef56838488323a141b023afebc188