### PR TITLE
Restrict admin console to authenticated admins

### DIFF
--- a/src/app/routes/AdminConsole.tsx
+++ b/src/app/routes/AdminConsole.tsx
@@ -1,7 +1,37 @@
+import { Link } from 'react-router-dom';
 import { PageContainer } from '@/components/layout/PageContainer.tsx';
 import { AdminForms } from '@/components/typing/AdminForms.tsx';
+import { useAuth } from '@/features/auth/contexts/AuthContext.tsx';
 
 export const AdminConsole = () => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return (
+      <PageContainer
+        title="管理コンソール"
+        description="コンテストの作成・プロンプト管理・ライブ監視を行います"
+      >
+        <p role="alert">
+          管理機能を利用するには
+          <Link to="/signin">ログイン</Link>
+          してください。
+        </p>
+      </PageContainer>
+    );
+  }
+
+  if (user.role !== 'admin') {
+    return (
+      <PageContainer
+        title="管理コンソール"
+        description="コンテストの作成・プロンプト管理・ライブ監視を行います"
+      >
+        <p role="alert">管理者権限を持つアカウントでのみ利用できます。</p>
+      </PageContainer>
+    );
+  }
+
   return (
     <PageContainer
       title="管理コンソール"

--- a/src/components/navigation/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar.tsx
@@ -10,16 +10,18 @@ type NavigationItem = {
   to?: string;
 };
 
-const staticLinks: NavigationItem[] = [
-  { key: 'home', to: '/', label: 'トップ' },
-  { key: 'dashboard', to: '/dashboard', label: 'ダッシュボード' },
-  { key: 'admin', to: '/admin', label: '管理コンソール' },
-];
-
 export const NavigationBar = () => {
   const { data: contests } = useContestsQuery();
   const leaderboardContestId = contests?.[0]?.id;
   const { user } = useAuth();
+
+  const staticLinks: NavigationItem[] = [
+    { key: 'home', to: '/', label: 'トップ' },
+    { key: 'dashboard', to: '/dashboard', label: 'ダッシュボード' },
+  ];
+  if (user?.role === 'admin') {
+    staticLinks.push({ key: 'admin', to: '/admin', label: '管理コンソール' });
+  }
 
   const leaderboardLink: NavigationItem = leaderboardContestId
     ? { key: 'leaderboard', to: `/leaderboard/${leaderboardContestId}`, label: 'ランキング' }


### PR DESCRIPTION
## Summary
- 管理者以外が管理コンソールにアクセスした際はログイン／権限不足のメッセージを表示するように調整しました
- ナビゲーションメニューの管理コンソールリンクを管理者ロールのユーザーに限定しました

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef6e4a76c8323845f04932b4e1747